### PR TITLE
Add CMAKE build support (crossplatform).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,80 @@
+# Minimum CMake required
+cmake_minimum_required(VERSION 3.5)
+
+if(WIN32)
+  if(${CMAKE_VERSION} VERSION_LESS "3.8")
+    message(WARNING "Your current cmake version is ${CMAKE_VERSION} which does not support setting the toolset architecture to x64. This may cause \"compiler out of heap space\" errors when building. Consider upgrading your cmake to > 3.8 and using the flag -Thost=x64 when running cmake.")
+  else()
+    if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE OR NOT "${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}" STREQUAL "x64")
+      message(WARNING "Your current cmake generator is set to use 32 bit toolset architecture. This may cause \"compiler out of heap space\" errors when building. Consider using the flag -Thost=x64 when running cmake.")
+    endif()
+  endif()
+endif()
+
+# Project
+project(xavna C CXX)
+
+set(xaVNA_VERSION_MAJOR 0)
+set(xaVNA_VERSION_MINOR 1)
+set(xaVNA_VERSION_STRING ${xaVNA_VERSION_MAJOR}.${xaVNA_VERSION_MINOR})
+
+# Set C++11 as standard for the whole project
+set(CMAKE_CXX_STANDARD 11)
+
+if(UNIX)
+  set(CMAKE_CXX_FLAGS "-O3" ${CMAKE_CXX_FLAGS})
+  set(CMAKE_CXX_FLAGS_DEBUG "-g ${CMAKE_CXX_FLAGS}")
+endif()
+
+# Set version
+add_definitions(-DVERSION=\"${xaVNA_VERSION_STRING}\")
+
+# CMake policies
+cmake_policy(SET CMP0022 NEW)
+
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Position independent code
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Local Include
+include_directories(include)
+
+# ==============================================================================
+# Eigen3
+# ==============================================================================
+find_package(Eigen3 REQUIRED)
+if(EIGEN3_FOUND)
+  message(STATUS "  eigen3 version: ${EIGEN3_VERSION}")
+  message(STATUS "  eigen3 includes: ${EIGEN3_INCLUDE_DIR}")
+  include_directories(${EIGEN3_INCLUDE_DIR})
+endif()
+
+# ==============================================================================
+# FFTW3
+# ==============================================================================
+find_package(FFTW3 REQUIRED)
+if(FFTW3_FOUND)
+  message(STATUS "Found FFTW3 (${FFTW3_VERSION})")
+  message(STATUS "  fftw3 includes: ${FFTW3_INCLUDE_DIRS}")
+  message(STATUS "  fftw3 libraries: ${FFTW3_LIBRARIES}")
+  include_directories(${FFTW3_INCLUDE_DIR})
+endif()
+
+# ==============================================================================
+# QT5 Charts (and QT5 subdependences)
+# ==============================================================================
+find_package(Qt5 COMPONENTS Core Gui Widgets Charts REQUIRED)
+if(Qt5Charts_FOUND)
+  message(STATUS "Found qt5 version: ${Qt5_VERSION}")
+  message(STATUS "  qt5 charts dir: ${Qt5Charts_DIR}")
+endif()
+
+# ==============================================================================
+# xaVNA subprojects
+# ==============================================================================
+add_subdirectory(libxavna)
+add_subdirectory(libxavna/xavna_mock_ui)
+add_subdirectory(vna_qt)
+

--- a/libxavna/CMakeLists.txt
+++ b/libxavna/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+set(libxavna_SRC xavna.C
+                 xavna_cpp.C
+                 calibration.C)
+
+if(WIN32)
+  list(APPEND libxavna_SRC platform_abstraction_windows.C)
+else()
+  list(APPEND libxavna_SRC platform_abstraction.C)
+endif()
+
+add_library(xavna SHARED ${libxavna_SRC})
+
+set_target_properties(xavna PROPERTIES
+                        VERSION ${xaVNA_VERSION_STRING}
+                        SOVERSION ${xaVNA_VERSION_MAJOR})
+
+target_link_libraries(xavna ${xa_LIBRARIES})
+
+# Declare destinations
+install(TARGETS xavna
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/libxavna/xavna_mock_ui/CMakeLists.txt
+++ b/libxavna/xavna_mock_ui/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+include_directories(${Qt5Charts_INCLUDE_DIRS})
+
+# Instruct CMake to run moc automatically when needed
+set(CMAKE_AUTOMOC ON)
+# Create code from a list of Qt designer ui files
+set(CMAKE_AUTOUIC ON)
+
+set(xavna_mock_ui_SRCS
+    xavna_mock_ui.C
+    xavna_mock.C
+    xavna_mock_ui_dialog.C)
+
+set(xavna_mock_ui_FRMS
+    xavna_mock_ui_dialog.ui)
+
+set(xavna_mock_ui_HDRS
+    xavna_mock_ui.H
+    xavna_mock_ui_dialog.H
+    xavna_mock_ui_global.h
+    ../include/calibration.H)
+
+add_library(xavna_mock_ui SHARED ${xavna_mock_ui_SRCS} ${xavna_mock_ui_FRMS} ${xavna_mock_ui_HDRS})
+
+set_target_properties(xavna_mock_ui PROPERTIES
+                          VERSION ${xaVNA_VERSION_STRING}
+                          SOVERSION ${xaVNA_VERSION_MAJOR})
+
+target_link_libraries(xavna_mock_ui Qt5::Core)
+
+# Declare destinations
+install(TARGETS xavna_mock_ui
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/vna_qt/CMakeLists.txt
+++ b/vna_qt/CMakeLists.txt
@@ -1,0 +1,57 @@
+
+include_directories(${Qt5Charts_INCLUDE_DIRS})
+
+# Instruct CMake to run moc automatically when needed
+set(CMAKE_AUTOMOC ON)
+# Create code from a list of Qt designer ui files
+set(CMAKE_AUTOUIC ON)
+
+set(vna_qt_SRCS
+    polarview.C
+    mainwindow.C
+    main.C
+    markerslider.C
+    impedancedisplay.C
+    frequencydialog.C
+    graphpanel.C
+    configureviewdialog.C
+    touchstone.C
+    calkitsettingsdialog.C
+    calkitsettings.C
+    networkview.C
+    dtfwindow.C)
+
+set(vna_qt_FRMS
+    mainwindow.ui
+    markerslider.ui
+    impedancedisplay.ui
+    frequencydialog.ui
+    graphpanel.ui
+    configureviewdialog.ui
+    calkitsettingsdialog.ui
+    calkitsettingswidget.ui
+    dtfwindow.ui
+    graphlimitsdialog.ui)
+
+set(vna_qt_HDRS
+    polarview.H
+    mainwindow.H
+    markerslider.H
+    impedancedisplay.H
+    utility.H
+    frequencydialog.H
+    graphpanel.H
+    configureviewdialog.H
+    touchstone.H
+    calkitsettingsdialog.H
+    calkitsettings.H
+    networkview.H
+    dtfwindow.H)
+
+
+add_executable(vna_qt ${vna_qt_SRCS} ${vna_qt_FRMS} ${vna_qt_HDRS})
+
+target_link_libraries(vna_qt Qt5::Charts ${FFTW3_LIBRARIES} xavna xavna_mock_ui)
+
+# Install destinations
+install(TARGETS vna_qt RUNTIME DESTINATION lib)


### PR DESCRIPTION
Dear @xaxaxa  & folks, 

 Proposed patch add CMake build support.

Some advantages:

  * guarantees smooth **cross platform** compilation
  * guarantees to find and **pickup** proper **external library dependencies** with ease
  * cmake build system enjoys **large community support** on **many platforms**
  * helps building & generating for **mswin visualstudio** and other platform IDE project files
  * autoconf & automake saga are notoriously hard to maintain (compared to cmake)


Since this is the first iteration of proposal, it could be not perfect, but its very easy to fix any possible upcoming glitches.


 Thank you very much !

------------------------

Sample build process:

```
mkdir BUILD
cd BUILD
cmake ../
-- The C compiler identification is GNU 8.2.1
-- The CXX compiler identification is GNU 8.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Eigen3: /usr/include/eigen3 (Required is at least version "2.91.0") 
--   eigen3 version: 3.3.5
--   eigen3 includes: /usr/include/eigen3
-- Found FFTW3 (3.3.8)
--   fftw3 includes: /usr/include
--   fftw3 libraries: fftw3
-- Found qt5 version: 5.11.2
--   qt5 charts dir: /usr/lib64/cmake/Qt5Charts
-- Configuring done
-- Generating done
-- Build files have been written to: /home/cbalint/work/GITHUB/vna/BUILD

$ make -j4
Scanning dependencies of target xavna_mock_ui_autogen
Scanning dependencies of target xavna
[  3%] Automatic MOC and UIC for target xavna_mock_ui
[ 11%] Building CXX object libxavna/CMakeFiles/xavna.dir/xavna_cpp.C.o
[ 11%] Building CXX object libxavna/CMakeFiles/xavna.dir/xavna.C.o
[ 14%] Building CXX object libxavna/CMakeFiles/xavna.dir/calibration.C.o
[ 14%] Built target xavna_mock_ui_autogen
Scanning dependencies of target xavna_mock_ui
[ 18%] Building CXX object libxavna/xavna_mock_ui/CMakeFiles/xavna_mock_ui.dir/xavna_mock_ui.C.o
[ 22%] Building CXX object libxavna/CMakeFiles/xavna.dir/platform_abstraction.C.o
[ 25%] Building CXX object libxavna/xavna_mock_ui/CMakeFiles/xavna_mock_ui.dir/xavna_mock.C.o
[ 29%] Building CXX object libxavna/xavna_mock_ui/CMakeFiles/xavna_mock_ui.dir/xavna_mock_ui_dialog.C.o
[ 33%] Building CXX object libxavna/xavna_mock_ui/CMakeFiles/xavna_mock_ui.dir/xavna_mock_ui_autogen/mocs_compilation.cpp.o
[ 37%] Linking CXX shared library libxavna.so
[ 40%] Linking CXX shared library libxavna_mock_ui.so
[ 40%] Built target xavna
[ 40%] Built target xavna_mock_ui
Scanning dependencies of target vna_qt_autogen
[ 44%] Automatic MOC and UIC for target vna_qt
[ 44%] Built target vna_qt_autogen
Scanning dependencies of target vna_qt
[ 48%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/polarview.C.o
[ 51%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/mainwindow.C.o
[ 55%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/main.C.o
[ 59%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/markerslider.C.o
[ 62%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/impedancedisplay.C.o
[ 66%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/frequencydialog.C.o
[ 70%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/graphpanel.C.o
[ 74%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/configureviewdialog.C.o
[ 77%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/touchstone.C.o
[ 81%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/calkitsettingsdialog.C.o
[ 85%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/calkitsettings.C.o
[ 88%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/networkview.C.o
[ 92%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/dtfwindow.C.o
[ 96%] Building CXX object vna_qt/CMakeFiles/vna_qt.dir/vna_qt_autogen/mocs_compilation.cpp.o
[100%] Linking CXX executable vna_qt
[100%] Built target vna_qt
```
