### PR TITLE
Fix segfault when compiled with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,21 @@ set(xaVNA_VERSION_STRING ${xaVNA_VERSION_MAJOR}.${xaVNA_VERSION_MINOR})
 set(CMAKE_CXX_STANDARD 11)
 
 if(UNIX)
-  set(CMAKE_CXX_FLAGS "-O3" ${CMAKE_CXX_FLAGS})
-  set(CMAKE_CXX_FLAGS_DEBUG "-g ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-O2 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "-O2 -g ${CMAKE_CXX_FLAGS}")
+endif()
+
+if(NOT LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR lib)
+endif()
+
+if(NOT BIN_INSTALL_DIR)
+    set(BIN_INSTALL_DIR bin)
 endif()
 
 # Set version
 add_definitions(-DVERSION=\"${xaVNA_VERSION_STRING}\")
+add_definitions(-DEIGEN_DONT_VECTORIZE -DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT)
 
 # CMake policies
 cmake_policy(SET CMP0022 NEW)
@@ -67,7 +76,7 @@ endif()
 # ==============================================================================
 find_package(Qt5 COMPONENTS Core Gui Widgets Charts REQUIRED)
 if(Qt5Charts_FOUND)
-  message(STATUS "Found qt5 version: ${Qt5_VERSION}")
+  message(STATUS "Found QT5 version: ${Qt5_VERSION}")
   message(STATUS "  qt5 charts dir: ${Qt5Charts_DIR}")
 endif()
 
@@ -77,4 +86,3 @@ endif()
 add_subdirectory(libxavna)
 add_subdirectory(libxavna/xavna_mock_ui)
 add_subdirectory(vna_qt)
-

--- a/libxavna/CMakeLists.txt
+++ b/libxavna/CMakeLists.txt
@@ -19,5 +19,5 @@ target_link_libraries(xavna ${xa_LIBRARIES})
 
 # Declare destinations
 install(TARGETS xavna
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+        ARCHIVE DESTINATION ${LIB_INSTALL_DIR})

--- a/libxavna/xavna_mock_ui/CMakeLists.txt
+++ b/libxavna/xavna_mock_ui/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_definitions(-DXAVNA_MOCK_UI_LIBRARY)
+
 include_directories(${Qt5Charts_INCLUDE_DIRS})
 
 # Instruct CMake to run moc automatically when needed
@@ -26,9 +28,9 @@ set_target_properties(xavna_mock_ui PROPERTIES
                           VERSION ${xaVNA_VERSION_STRING}
                           SOVERSION ${xaVNA_VERSION_MAJOR})
 
-target_link_libraries(xavna_mock_ui Qt5::Core)
+target_link_libraries(xavna_mock_ui Qt5::Core Qt5::Widgets Qt5::Gui xavna)
 
 # Declare destinations
 install(TARGETS xavna_mock_ui
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+        ARCHIVE DESTINATION ${LIB_INSTALL_DIR})

--- a/vna_qt/CMakeLists.txt
+++ b/vna_qt/CMakeLists.txt
@@ -54,4 +54,4 @@ add_executable(vna_qt ${vna_qt_SRCS} ${vna_qt_FRMS} ${vna_qt_HDRS})
 target_link_libraries(vna_qt Qt5::Charts ${FFTW3_LIBRARIES} xavna xavna_mock_ui)
 
 # Install destinations
-install(TARGETS vna_qt RUNTIME DESTINATION lib)
+install(TARGETS vna_qt RUNTIME DESTINATION ${BIN_INSTALL_DIR})


### PR DESCRIPTION
Hi @xaxaxa ,

 This patch fix **segfault** on linux when compiled using cmake. 

* The segfault was due to improper linkage of ```vna_qt``` against ```Qt5 GL xavna``` libraries.

 It also fixes some minor issues:

  * typo for ```UNIX``` case in cmake.
  * add compile declaration just as original workflow (eigen3, qt5 related)
  * enable optional custom install path (demanded by distro packagers)

In the end ```vna_qt``` does not crash anymore.
