### PR TITLE
Fix compile error with gcc 10.1

### DIFF
--- a/libxavna/xavna_mock_ui/xavna_mock_ui.H
+++ b/libxavna/xavna_mock_ui/xavna_mock_ui.H
@@ -1,7 +1,9 @@
 #ifndef XAVNA_MOCK_UI_H
 #define XAVNA_MOCK_UI_H
 
+#include <string>
 #include <functional>
+
 using namespace std;
 typedef function<void(string dut_name, double cableLen1, double cableLen2)> xavna_ui_changed_cb;
 


### PR DESCRIPTION
Newer GCC is more picky about proper header inclusion.


See error without the PR:
```
In file included from /home/cbalint/rpmbuild/BUILD/vna/libxavna/xavna_mock_ui/xavna_mock_ui.C:1:
/home/cbalint/rpmbuild/BUILD/vna/libxavna/xavna_mock_ui/xavna_mock_ui.H:6:23: error: ‘string’ was not declared in this scope
    6 | typedef function<void(string dut_name, double cableLen1, double cableLen2)> xavna_ui_changed_cb;
      |                       ^~~~~~
/home/cbalint/rpmbuild/BUILD/vna/libxavna/xavna_mock_ui/xavna_mock_ui.H:5:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
    4 | #include <functional>
  +++ |+#include <string>
    5 | using namespace st
```